### PR TITLE
fix: Update null check for password in PDF signing

### DIFF
--- a/src/main/java/com/zerodha/jpdfsigner/OpenPdfSigner.java
+++ b/src/main/java/com/zerodha/jpdfsigner/OpenPdfSigner.java
@@ -30,7 +30,7 @@ public class OpenPdfSigner {
         PdfStamper stp = PdfStamper.createSignature(reader, os, '\0', null);
 
         // Is there a password?
-        if (params.getPassword().length() > 0) {
+        if (params.getPassword() != null && !params.getPassword().isEmpty()) {
             byte[] p = params.getPassword().getBytes();
 
             // PdfWriter.DO_NOT_ENCRYPT_METADATA somehow disables password protection.

--- a/src/main/java/com/zerodha/jpdfsigner/SigningRequest.java
+++ b/src/main/java/com/zerodha/jpdfsigner/SigningRequest.java
@@ -12,7 +12,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
 public class SigningRequest {


### PR DESCRIPTION
Prevent NullPointerException by first checking if the password is null before checking if it's empty.
This enables signing without password/encryption.